### PR TITLE
Add react lint to .ts files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@caspeco/eslint-config",
-	"version": "3.0.0",
+	"version": "4.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@caspeco/eslint-config",
-			"version": "3.0.0",
+			"version": "4.0.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@caspeco/prettier-config": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@caspeco/eslint-config",
-	"version": "3.0.0",
+	"version": "4.0.0",
 	"homepage": "https://github.com/caspeco/eslint-config#readme",
 	"bugs": {
 		"url": "https://github.com/caspeco/eslint-config/issues"

--- a/src/frontend-react.js
+++ b/src/frontend-react.js
@@ -10,7 +10,7 @@ import globals from "globals";
 const flatConfig = [
 	...frontendVanilla,
 	{
-		files: ["**/*.ts","**/*.tsx", "**/*.jsx"],
+		files: ["**/*.ts", "**/*.tsx", "**/*.jsx"],
 		settings: {
 			react: {
 				version: "detect",

--- a/src/frontend-react.js
+++ b/src/frontend-react.js
@@ -11,7 +11,7 @@ import globals from "globals";
 const flatConfig = [
 	...frontendVanilla,
 	{
-		files: ["**/*.tsx", "**/*.jsx"],
+		files: ["**/*.ts","**/*.tsx", "**/*.jsx"],
 		settings: {
 			react: {
 				version: "detect",


### PR DESCRIPTION
Hooks brukar ju typ alltid skapas i `.ts`-filer. Märkte att jag inte fick någon eslint-rules-of-hooks när jag satt och hackade runt lite, så vi vill nog slå på detta i `.ts`-filer.

Osäker på om det är några andra JSX-specifika regler som kommer förstöra om man kör de i vanlig TypeScript, men skulle gissa att det är fine. Däremot kommer det säkert bli en hel del nya lintproblem för många...

(@parse finns det något enkelt sätt för mig att testa detta? alphaversion kanske?)