### PR TITLE
chore: replace deprecated read-package-engines-version-actions with node-version-file

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -14,14 +14,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Read node and npm versions from package.json
-        uses: skjnldsv/read-package-engines-version-actions@v3
-        id: package-engines-versions
-
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ steps.package-engines-versions.outputs.nodeVersion }}
+          node-version-file: "package.json"
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Read node and npm versions from package.json
-        uses: skjnldsv/read-package-engines-version-actions@v3
-        id: package-engines-versions
-
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ steps.package-engines-versions.outputs.nodeVersion }}
+          node-version-file: "package.json"
 
       - run: npm ci
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1788,9 +1788,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
## Problem
`skjnldsv/read-package-engines-version-actions` runs on Node 20 and is deprecated (no Node 24 release). It will stop working.

## Fix
Drop the action; use `actions/setup-node`'s native `node-version-file` input pointing at `package.json`, which reads `engines.node` directly. No downstream output (`npmVersion`) was used. Same approach as Caspeco/AccessManagement#760.

> Note: `release.yml` is only triggered on GitHub releases, so it won't be exercised by this PR's CI — correctness rests on the diff matching the proven pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)