### PR TITLE
feat(react): add opt-in React Compiler config

### DIFF
--- a/packages/eslint-config-react/README.md
+++ b/packages/eslint-config-react/README.md
@@ -32,6 +32,24 @@ import config from "@caspeco/eslint-config-react";
 export default [{ ignores: ["dist/**/*", "build/**/*"] }, ...config];
 ```
 
+### React Compiler (opt-in)
+
+If your project has adopted the [React Compiler](https://react.dev/learn/react-compiler), use the
+`/compiler` entry point instead. It is a drop-in replacement that enables the full
+`eslint-plugin-react-hooks` recommended ruleset, including the React Compiler rules
+(`react-hooks/purity`, `react-hooks/static-components`, `react-hooks/use-memo`,
+`react-hooks/immutability`, `react-hooks/set-state-in-render`, and more):
+
+```js
+import config from "@caspeco/eslint-config-react/compiler";
+
+export default [{ ignores: ["dist/**/*", "build/**/*"] }, ...config];
+```
+
+The default config (`@caspeco/eslint-config-react`) intentionally enables only
+`react-hooks/rules-of-hooks` and `react-hooks/exhaustive-deps`, so teams that have not
+yet adopted the React Compiler are not flooded with compiler-specific warnings.
+
 ## What's Included
 
 This configuration includes everything from our TypeScript config plus React-specific rules:

--- a/packages/eslint-config-react/__tests__/fixtures/react-compiler/eslint.config.js
+++ b/packages/eslint-config-react/__tests__/fixtures/react-compiler/eslint.config.js
@@ -1,0 +1,3 @@
+import reactCompilerConfig from "@/eslint-config-react/compiler";
+
+export default reactCompilerConfig;

--- a/packages/eslint-config-react/__tests__/fixtures/react-compiler/purity.tsx
+++ b/packages/eslint-config-react/__tests__/fixtures/react-compiler/purity.tsx
@@ -1,0 +1,6 @@
+// 🔴 Bad: calling an impure function (Math.random) during render.
+// Flagged by react-hooks/purity, a React Compiler rule that is only enabled
+// in the opt-in compiler config — not in the default config.
+export function Bad() {
+  return <div>{Math.random()}</div>;
+}

--- a/packages/eslint-config-react/__tests__/fixtures/react-compiler/tsconfig.json
+++ b/packages/eslint-config-react/__tests__/fixtures/react-compiler/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"allowJs": true,
+		"useDefineForClassFields": true,
+		"module": "ESNext",
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"skipLibCheck": true,
+
+		/* Bundler mode */
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+
+		/* Linting */
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true
+	},
+}

--- a/packages/eslint-config-react/__tests__/validate-react-compiler.test.ts
+++ b/packages/eslint-config-react/__tests__/validate-react-compiler.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import eslint from "eslint";
+import compilerConfig from "./fixtures/react-compiler/eslint.config";
+import defaultConfig from "./fixtures/react/eslint.config";
+import { assertHasEslintError } from "@caspeco/test-utils/utils/has-eslint-error";
+
+const PURITY_FIXTURE = "__tests__/fixtures/react-compiler/purity.tsx";
+
+const hasRule = (result: eslint.ESLint.LintResult[], ruleId: string) =>
+	result.some((file) => file.messages.some((message) => message.ruleId === ruleId));
+
+describe("validate react compiler config", () => {
+	describe("react compiler rules (opt-in)", () => {
+		it("flags react-hooks/purity under the compiler config", async () => {
+			const cli = new eslint.ESLint({
+				overrideConfig: compilerConfig as eslint.ESLint.Options["overrideConfig"],
+				overrideConfigFile: true,
+			});
+
+			const result = await cli.lintFiles(PURITY_FIXTURE);
+			assertHasEslintError(result, "react-hooks/purity");
+		});
+
+		it("does NOT flag react-hooks/purity under the default config", async () => {
+			const cli = new eslint.ESLint({
+				overrideConfig: defaultConfig as eslint.ESLint.Options["overrideConfig"],
+				overrideConfigFile: true,
+			});
+
+			const result = await cli.lintFiles(PURITY_FIXTURE);
+			expect(hasRule(result, "react-hooks/purity")).toBe(false);
+		});
+	});
+
+	describe("base react-hooks rules (superset)", () => {
+		it("still flags react-hooks/rules-of-hooks under the compiler config", async () => {
+			const cli = new eslint.ESLint({
+				overrideConfig: compilerConfig as eslint.ESLint.Options["overrideConfig"],
+				overrideConfigFile: true,
+			});
+
+			const result = await cli.lintFiles("__tests__/fixtures/react/react-hooks.tsx");
+			assertHasEslintError(result, "react-hooks/rules-of-hooks");
+		});
+	});
+});

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -20,6 +20,17 @@
 	},
 	"license": "MIT",
 	"type": "module",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./src/index.js"
+		},
+		"./compiler": {
+			"types": "./dist/compiler.d.ts",
+			"default": "./src/compiler.js"
+		},
+		"./package.json": "./package.json"
+	},
 	"main": "src/index.js",
 	"types": "dist/index.d.ts",
 	"bin": {
@@ -32,7 +43,7 @@
 	],
 	"scripts": {
 		"build": "tsc --project tsconfig.build.json",
-		"check:types": "attw --pack . --ignore-rules=cjs-resolves-to-esm",
+		"check:types": "attw --pack . --ignore-rules=cjs-resolves-to-esm --profile node16",
 		"prepublishOnly": "npm run build",
 		"test": "vitest"
 	},

--- a/packages/eslint-config-react/src/compiler.js
+++ b/packages/eslint-config-react/src/compiler.js
@@ -8,7 +8,9 @@ import { createConfig } from "./create-config.js";
 // React Compiler. It is a superset of the default config.
 /** @type {import('typescript-eslint').ConfigArray} */
 const flatConfig = createConfig({
-	...reactHooksPlugin.configs.recommended.rules,
+	reactHooksRules: {
+		...reactHooksPlugin.configs.recommended.rules,
+	},
 });
 
 export default flatConfig;

--- a/packages/eslint-config-react/src/compiler.js
+++ b/packages/eslint-config-react/src/compiler.js
@@ -1,0 +1,14 @@
+import reactHooksPlugin from "eslint-plugin-react-hooks";
+import { createConfig } from "./create-config.js";
+
+// React Compiler opt-in config: enables the full `eslint-plugin-react-hooks`
+// recommended ruleset, which includes the React Compiler specific rules
+// (e.g. static-components, use-memo, immutability, purity, set-state-in-render).
+// Use this instead of the default config once your project has adopted the
+// React Compiler. It is a superset of the default config.
+/** @type {import('typescript-eslint').ConfigArray} */
+const flatConfig = createConfig({
+	...reactHooksPlugin.configs.recommended.rules,
+});
+
+export default flatConfig;

--- a/packages/eslint-config-react/src/compiler.js
+++ b/packages/eslint-config-react/src/compiler.js
@@ -1,11 +1,6 @@
 import reactHooksPlugin from "eslint-plugin-react-hooks";
 import { createConfig } from "./create-config.js";
 
-// React Compiler opt-in config: enables the full `eslint-plugin-react-hooks`
-// recommended ruleset, which includes the React Compiler specific rules
-// (e.g. static-components, use-memo, immutability, purity, set-state-in-render).
-// Use this instead of the default config once your project has adopted the
-// React Compiler. It is a superset of the default config.
 /** @type {import('typescript-eslint').ConfigArray} */
 const flatConfig = createConfig({
 	reactHooksRules: {

--- a/packages/eslint-config-react/src/create-config.js
+++ b/packages/eslint-config-react/src/create-config.js
@@ -1,0 +1,73 @@
+import tsConfig from "@caspeco/eslint-config-ts";
+import reactRefresh from "eslint-plugin-react-refresh";
+import reactPlugin from "eslint-plugin-react";
+import reactHooksPlugin from "eslint-plugin-react-hooks";
+import caspecoReactPlugin from "./plugins/caspeco-react.js";
+import globals from "globals";
+
+/**
+ * Builds the Caspeco React flat config. The only part that varies between the
+ * default and the React Compiler opt-in config is the set of `react-hooks` rules.
+ *
+ * @param {import('eslint').Linter.RulesRecord} reactHooksRules
+ * @returns {import('typescript-eslint').ConfigArray}
+ */
+export function createConfig(reactHooksRules) {
+	return [
+		// Extend the vanilla TypeScript config
+		...tsConfig,
+		// React plugin recommended config
+		{
+			...reactPlugin.configs.flat?.recommended,
+			files: ["**/*.ts", "**/*.tsx", "**/*.jsx"],
+			settings: {
+				react: {
+					version: "detect",
+				},
+			},
+			languageOptions: {
+				...reactPlugin.configs.flat?.recommended.languageOptions,
+				globals: {
+					...globals.serviceworker,
+					...globals.browser,
+				},
+				parserOptions: {
+					...reactPlugin.configs.flat?.recommended.languageOptions?.parserOptions,
+					ecmaVersion: "latest",
+				},
+			},
+			rules: {
+				...reactPlugin.configs.flat?.recommended.rules,
+				"react/react-in-jsx-scope": "off",
+				"react/prop-types": "off",
+				"react/display-name": "off",
+			},
+		},
+		// React hooks plugin config
+		{
+			...reactHooksPlugin.configs.recommended,
+			plugins: { "react-hooks": reactHooksPlugin },
+			files: ["**/*.ts", "**/*.tsx", "**/*.jsx"],
+			rules: reactHooksRules,
+		},
+		// React refresh plugin config
+		{
+			...reactRefresh.configs.recommended,
+			files: ["**/*.ts", "**/*.tsx", "**/*.jsx"],
+			rules: {
+				...reactRefresh.configs.recommended.rules,
+				"react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+			},
+		},
+		// Caspeco React custom rules
+		{
+			files: ["**/*.ts", "**/*.tsx", "**/*.jsx"],
+			plugins: {
+				"caspeco-react": caspecoReactPlugin,
+			},
+			rules: {
+				"caspeco-react/discourage-chakra-import": "error",
+			},
+		},
+	];
+}

--- a/packages/eslint-config-react/src/create-config.js
+++ b/packages/eslint-config-react/src/create-config.js
@@ -9,10 +9,11 @@ import globals from "globals";
  * Builds the Caspeco React flat config. The only part that varies between the
  * default and the React Compiler opt-in config is the set of `react-hooks` rules.
  *
- * @param {import('eslint').Linter.RulesRecord} reactHooksRules
+ * @param {object} options
+ * @param {import('eslint').Linter.RulesRecord} options.reactHooksRules
  * @returns {import('typescript-eslint').ConfigArray}
  */
-export function createConfig(reactHooksRules) {
+export function createConfig({ reactHooksRules }) {
 	return [
 		// Extend the vanilla TypeScript config
 		...tsConfig,

--- a/packages/eslint-config-react/src/index.js
+++ b/packages/eslint-config-react/src/index.js
@@ -6,8 +6,10 @@ import { createConfig } from "./create-config.js";
 // https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks#flat-config-eslintconfigjsts-1
 /** @type {import('typescript-eslint').ConfigArray} */
 const flatConfig = createConfig({
-	"react-hooks/rules-of-hooks": "error",
-	"react-hooks/exhaustive-deps": "warn",
+	reactHooksRules: {
+		"react-hooks/rules-of-hooks": "error",
+		"react-hooks/exhaustive-deps": "warn",
+	},
 });
 
 export default flatConfig;

--- a/packages/eslint-config-react/src/index.js
+++ b/packages/eslint-config-react/src/index.js
@@ -1,74 +1,13 @@
-import tsConfig from "@caspeco/eslint-config-ts";
-import reactRefresh from "eslint-plugin-react-refresh";
-import reactPlugin from "eslint-plugin-react";
-import reactHooksPlugin from "eslint-plugin-react-hooks";
-import caspecoReactPlugin from "./plugins/caspeco-react.js";
-import globals from "globals";
+import { createConfig } from "./create-config.js";
 
+// Default config: only the rules of hooks and exhaustive deps. We intentionally
+// skip the React Compiler specific rules here — teams that have adopted the
+// React Compiler should use the `@caspeco/eslint-config-react/compiler` config.
+// https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks#flat-config-eslintconfigjsts-1
 /** @type {import('typescript-eslint').ConfigArray} */
-const flatConfig = [
-	// Extend the vanilla TypeScript config
-	...tsConfig,
-	// React plugin recommended config
-	{
-		...reactPlugin.configs.flat?.recommended,
-		files: ["**/*.ts", "**/*.tsx", "**/*.jsx"],
-		settings: {
-			react: {
-				version: "detect",
-			},
-		},
-		languageOptions: {
-			...reactPlugin.configs.flat?.recommended.languageOptions,
-			globals: {
-				...globals.serviceworker,
-				...globals.browser,
-			},
-			parserOptions: {
-				...reactPlugin.configs.flat?.recommended.languageOptions?.parserOptions,
-				ecmaVersion: "latest",
-			},
-		},
-		rules: {
-			...reactPlugin.configs.flat?.recommended.rules,
-			"react/react-in-jsx-scope": "off",
-			"react/prop-types": "off",
-			"react/display-name": "off",
-		},
-	},
-	// React hooks plugin recommended config
-	{
-		...reactHooksPlugin.configs.recommended,
-		plugins: { "react-hooks": reactHooksPlugin },
-		files: ["**/*.ts", "**/*.tsx", "**/*.jsx"],
-		rules: {
-			"react-hooks/rules-of-hooks": "error",
-			"react-hooks/exhaustive-deps": "warn",
-			// We ignore the compiler specific rules as we need React 19 for this.
-			// https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks#flat-config-eslintconfigjsts-1
-			// When we support this, we can add:
-			// ...reactHooksPlugin.configs.recommended.rules,
-		},
-	},
-	// React refresh plugin config
-	{
-		...reactRefresh.configs.recommended,
-		files: ["**/*.ts", "**/*.tsx", "**/*.jsx"],
-		rules: {
-			...reactRefresh.configs.recommended.rules,
-			"react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
-		},
-	},
-	// Caspeco React custom rules
-	{
-		files: ["**/*.ts", "**/*.tsx", "**/*.jsx"],
-		plugins: {
-			"caspeco-react": caspecoReactPlugin,
-		},
-		rules: {
-			"caspeco-react/discourage-chakra-import": "error",
-		},
-	},
-];
+const flatConfig = createConfig({
+	"react-hooks/rules-of-hooks": "error",
+	"react-hooks/exhaustive-deps": "warn",
+});
 
 export default flatConfig;

--- a/packages/eslint-config-react/src/index.js
+++ b/packages/eslint-config-react/src/index.js
@@ -1,9 +1,5 @@
 import { createConfig } from "./create-config.js";
 
-// Default config: only the rules of hooks and exhaustive deps. We intentionally
-// skip the React Compiler specific rules here — teams that have adopted the
-// React Compiler should use the `@caspeco/eslint-config-react/compiler` config.
-// https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks#flat-config-eslintconfigjsts-1
 /** @type {import('typescript-eslint').ConfigArray} */
 const flatConfig = createConfig({
 	reactHooksRules: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
 		"baseUrl": ".",
 		"paths": {
 			"@/eslint-config-ts": ["./packages/eslint-config-ts/src/index.js"],
+			"@/eslint-config-react/compiler": ["./packages/eslint-config-react/src/compiler.js"],
 			"@/eslint-config-react": ["./packages/eslint-config-react/src/index.js"]
 		}
 	},

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
 			"@/eslint-config-ts": fileURLToPath(
 				new URL("./packages/eslint-config-ts/src/index.js", import.meta.url),
 			),
+			"@/eslint-config-react/compiler": fileURLToPath(
+				new URL("./packages/eslint-config-react/src/compiler.js", import.meta.url),
+			),
 			"@/eslint-config-react": fileURLToPath(
 				new URL("./packages/eslint-config-react/src/index.js", import.meta.url),
 			),


### PR DESCRIPTION
## What

Exposes a new opt-in config for teams that have adopted the React Compiler:

```js
import config from "@caspeco/eslint-config-react/compiler";
export default [{ ignores: ["dist/**/*"] }, ...config];
```

It's a drop-in replacement that enables the **full** `eslint-plugin-react-hooks` recommended ruleset (the React Compiler rules: `purity`, `static-components`, `use-memo`, `immutability`, `set-state-in-render`, …). The default config (`@caspeco/eslint-config-react`) is unchanged — still just `rules-of-hooks` + `exhaustive-deps`.

## How

- Shared logic extracted to `src/create-config.js`; default and compiler entry points differ only in the `react-hooks` rules block.
- Added an `exports` map (`.` + `./compiler`). `check:types` now uses `--profile node16` (node10 predates subpath exports; this package requires `node >=24`).
- New fixture + test assert the compiler rule fires under `/compiler` and **not** under the default config.

## Note

Adding `exports` closes the package entry points — deep imports like `@caspeco/eslint-config-react/src/...` are no longer resolvable (intended).