### PR TITLE
Add eslint-plugin-baseline-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@caspeco/eslint-config",
-	"version": "5.2.1",
+	"version": "5.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@caspeco/eslint-config",
-			"version": "5.2.1",
+			"version": "5.4.0",
 			"license": "MIT",
 			"workspaces": [
 				"packages/*"
@@ -7226,10 +7226,10 @@
 		},
 		"packages/eslint-config-react": {
 			"name": "@caspeco/eslint-config-react",
-			"version": "5.2.1",
+			"version": "5.4.0",
 			"license": "MIT",
 			"dependencies": {
-				"@caspeco/eslint-config-ts": "5.2.1"
+				"@caspeco/eslint-config-ts": "5.4.0"
 			},
 			"bin": {
 				"caspeco-react-migrate-v5": "bin/caspeco-react-migrate-v5.js"
@@ -7256,7 +7256,7 @@
 		},
 		"packages/eslint-config-ts": {
 			"name": "@caspeco/eslint-config-ts",
-			"version": "5.2.1",
+			"version": "5.4.0",
 			"license": "MIT",
 			"bin": {
 				"caspeco-ts-migrate-v5": "bin/caspeco-ts-migrate-v5.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1791,9 +1791,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2975,6 +2975,22 @@
 				"eslint": ">=7.0.0"
 			}
 		},
+		"node_modules/eslint-plugin-baseline-js": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-baseline-js/-/eslint-plugin-baseline-js-0.7.0.tgz",
+			"integrity": "sha512-wnL74O4s+6y6Q8K+r64G0hL/RNZsXVJXM7U8x+Lf/ti/4vTMywGYcVSnkcuQG46tFtdo3lNZcGgIdOTEQ6i7oQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eslint-plugin-es-x": "^9.7.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=9.29.0 <11"
+			}
+		},
 		"node_modules/eslint-plugin-check-file": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-check-file/-/eslint-plugin-check-file-3.3.1.tgz",
@@ -3003,6 +3019,28 @@
 			},
 			"peerDependencies": {
 				"eslint": ">=9.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-es-x": {
+			"version": "9.7.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-9.7.0.tgz",
+			"integrity": "sha512-BT0pUw0toxtrHulYycGiUTL++qC11opyPYMuGUR7AgmuQ/N1YN1xLupF8rGxlaGqEqkqeedJuacCxxAcYgGkvg==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/ota-meshi",
+				"https://opencollective.com/eslint"
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.1.2",
+				"@eslint-community/regexpp": "^4.12.1",
+				"eslint-type-tracer": "^0.5.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=9.29.0"
 			}
 		},
 		"node_modules/eslint-plugin-no-barrel-files": {
@@ -3129,6 +3167,25 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-type-tracer": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/eslint-type-tracer/-/eslint-type-tracer-0.5.2.tgz",
+			"integrity": "sha512-YiJmgk6OD1suPB4UC3M/PB+oxahf145jQQ5gFXFk9F9Y7puWwnqGYC2BtTB+FoHqdOohImeTt0rNk0lhhECNaQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.7.0"
+			},
+			"engines": {
+				"node": "^18 || >=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ota-meshi"
+			},
+			"peerDependencies": {
+				"eslint": ">=8"
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
@@ -4325,9 +4382,9 @@
 			"dev": true
 		},
 		"node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -7209,6 +7266,7 @@
 				"@eslint/js": "^9.39.4",
 				"eslint": "^9.39.4",
 				"eslint-config-prettier": "^10.1.8",
+				"eslint-plugin-baseline-js": "^0.7.0",
 				"eslint-plugin-check-file": "^3.3.1",
 				"eslint-plugin-no-barrel-files": "^1.3.1",
 				"typescript-eslint": "^8.59.1"
@@ -7221,6 +7279,7 @@
 				"@eslint/js": "^9.39.4",
 				"eslint": "^9.39.4",
 				"eslint-config-prettier": "^10.1.8",
+				"eslint-plugin-baseline-js": "^0.7.0",
 				"eslint-plugin-check-file": "^3.3.1",
 				"eslint-plugin-no-barrel-files": "^1.2.2",
 				"typescript-eslint": "^8.57.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@caspeco/eslint-config",
-	"version": "5.2.1",
+	"version": "5.4.0",
 	"private": true,
 	"homepage": "https://github.com/Caspeco/eslint-config#readme",
 	"bugs": {

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@caspeco/eslint-config-react",
-	"version": "5.2.1",
+	"version": "5.4.0",
 	"description": "Caspeco ESLint configuration for React projects",
 	"keywords": [
 		"eslint",
@@ -48,7 +48,7 @@
 		"test": "vitest"
 	},
 	"dependencies": {
-		"@caspeco/eslint-config-ts": "5.2.1"
+		"@caspeco/eslint-config-ts": "5.4.0"
 	},
 	"devDependencies": {
 		"@caspeco/test-utils": "*",

--- a/packages/eslint-config-ts/package.json
+++ b/packages/eslint-config-ts/package.json
@@ -40,6 +40,7 @@
 		"@eslint/js": "^9.39.4",
 		"eslint": "^9.39.4",
 		"eslint-config-prettier": "^10.1.8",
+		"eslint-plugin-baseline-js": "^0.7.0",
 		"eslint-plugin-check-file": "^3.3.1",
 		"eslint-plugin-no-barrel-files": "^1.3.1",
 		"typescript-eslint": "^8.59.1"
@@ -48,6 +49,7 @@
 		"@eslint/js": "^9.39.4",
 		"eslint": "^9.39.4",
 		"eslint-config-prettier": "^10.1.8",
+		"eslint-plugin-baseline-js": "^0.7.0",
 		"eslint-plugin-check-file": "^3.3.1",
 		"eslint-plugin-no-barrel-files": "^1.2.2",
 		"typescript-eslint": "^8.57.2"

--- a/packages/eslint-config-ts/package.json
+++ b/packages/eslint-config-ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@caspeco/eslint-config-ts",
-	"version": "5.2.1",
+	"version": "5.4.0",
 	"description": "Caspeco ESLint configuration for TypeScript projects",
 	"keywords": [
 		"eslint",

--- a/packages/eslint-config-ts/src/index.js
+++ b/packages/eslint-config-ts/src/index.js
@@ -3,11 +3,13 @@ import js from "@eslint/js";
 import checkFile from "eslint-plugin-check-file";
 import eslintConfigPrettier from "eslint-config-prettier";
 import noBarrelFilesPlugin from "eslint-plugin-no-barrel-files";
+import baselineJs from "eslint-plugin-baseline-js";
 
 /** @type {import('typescript-eslint').ConfigArray} */
 const flatConfig = [
 	js.configs.recommended,
 	...typescriptEslintConfig.recommendedTypeChecked,
+	{ ...baselineJs.configs["recommended-ts"]({ available: "widely", level: "warn" }) },
 	{
 		languageOptions: {
 			parserOptions: {
@@ -31,6 +33,7 @@ const flatConfig = [
 			"@typescript-eslint": plugin,
 			"check-file": checkFile,
 			"no-barrel-files": noBarrelFilesPlugin,
+			"baseline-js": baselineJs,
 		},
 		rules: {
 			eqeqeq: ["error", "always"],

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -4,8 +4,7 @@
  * Also updates inter-workspace dependencies
  */
 
-import fs from "fs";
-import path from "path";
+import { execFileSync } from "child_process";
 
 const version = process.argv[2];
 
@@ -23,67 +22,34 @@ if (!semverPattern.test(version)) {
 	process.exit(1);
 }
 
-interface PackageJson {
-	name?: string;
-	version?: string;
-	dependencies?: Record<string, string>;
-	devDependencies?: Record<string, string>;
+function npm(args: string[]): void {
+	execFileSync("npm", args, { stdio: "inherit", shell: true });
 }
-
-function readPackageJson(filePath: string): PackageJson {
-	const content = fs.readFileSync(filePath, "utf-8");
-	return JSON.parse(content);
-}
-
-function writePackageJson(filePath: string, pkg: PackageJson): void {
-	const content = JSON.stringify(pkg, null, "\t") + "\n";
-	fs.writeFileSync(filePath, content, "utf-8");
-}
-
-const workspacePackages = [
-	"package.json",
-	"packages/eslint-config-ts/package.json",
-	"packages/eslint-config-react/package.json",
-	"packages/test-utils/package.json",
-];
 
 console.log(`Updating all packages to version ${version}...\n`);
 
-// Step 1: Update all package versions
-for (const pkgPath of workspacePackages) {
-	const fullPath = path.resolve(pkgPath);
-	if (!fs.existsSync(fullPath)) {
-		console.warn(`Warning: ${pkgPath} not found, skipping`);
-		continue;
-	}
+// Step 1: Point eslint-config-react at the new eslint-config-ts version before
+// bumping, so `npm version` below resolves it to the local workspace when it
+// writes package-lock.json (no registry lookup, no separate lock resync).
+npm([
+	"pkg",
+	"set",
+	`dependencies.@caspeco/eslint-config-ts=${version}`,
+	"--workspace=packages/eslint-config-react",
+]);
 
-	const pkg = readPackageJson(fullPath);
-
-	// Skip test-utils if it has its own versioning
-	if (pkg.name === "@caspeco/test-utils") {
-		console.log(`✓ ${pkgPath} - keeping version ${pkg.version} (utility package)`);
-		continue;
-	}
-
-	const oldVersion = pkg.version;
-	pkg.version = version;
-	writePackageJson(fullPath, pkg);
-
-	console.log(`✓ ${pkgPath} - ${oldVersion} → ${version}`);
-}
-
-// Step 2: Update inter-workspace dependencies
-console.log("\nUpdating inter-workspace dependencies...\n");
-
-const reactPkgPath = "packages/eslint-config-react/package.json";
-const reactPkg = readPackageJson(reactPkgPath);
-
-if (reactPkg.dependencies?.["@caspeco/eslint-config-ts"]) {
-	const oldDep = reactPkg.dependencies["@caspeco/eslint-config-ts"];
-	reactPkg.dependencies["@caspeco/eslint-config-ts"] = version;
-	writePackageJson(reactPkgPath, reactPkg);
-	console.log(`✓ eslint-config-react dependency: ${oldDep} → ${version}`);
-}
+// Step 2: Bump the root package and versioned workspaces via `npm version`.
+// This keeps package.json and package-lock.json in sync in one step.
+// test-utils is intentionally omitted - it has its own versioning.
+npm([
+	"version",
+	version,
+	"--workspace=packages/eslint-config-ts",
+	"--workspace=packages/eslint-config-react",
+	"--include-workspace-root",
+	"--no-git-tag-version",
+	"--allow-same-version",
+]);
 
 console.log("\n✅ All versions updated successfully!");
 console.log("\nNext steps:");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,6 @@
 		"noFallthroughCasesInSwitch": true,
 
 		/* Path aliases */
-		"baseUrl": ".",
 		"paths": {
 			"@/eslint-config-ts": ["./packages/eslint-config-ts/src/index.js"],
 			"@/eslint-config-react/compiler": ["./packages/eslint-config-react/src/compiler.js"],
@@ -33,7 +32,7 @@
 		"packages/*/src/**/*.js",
 		"packages/*/__tests__/**/*.ts",
 		"packages/*/__tests__/**/*.tsx",
-		"scripts/verify-versions.ts"
+		"scripts/**/*.ts"
 	],
 	"exclude": ["packages/*/__tests__/fixtures/**/*"]
 }


### PR DESCRIPTION
- Add new rules for detecting features that are too new to release (not baseline widely available).
- Fixes the bump versions script